### PR TITLE
feat: expose grpc port

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,15 @@ curl -s -X POST localhost:26657/status | jq
 curl -s -X POST localhost:26657/block | jq
 ```
 
+### gRPC
+
+To inspect the gRPC results on port 9090 you may [install grpcurl](https://github.com/fullstorydev/grpcurl?tab=readme-ov-file#installation).
+
+Once installed:
+```bash
+grpcurl -plaintext localhost:9090 list
+```
+
 ### Watch the height
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     ports:
       - "26657:26657"
       - "26656:26656"
+      - "9090:9090" # gRPC runs on port 9090
     restart: unless-stopped
     depends_on:
       init-priv-validator-state:


### PR DESCRIPTION
Adds a single line to `poktroll-docker-compose-example/docker-compose.yml` to expose port `9090` on which the gRPC endpoint is running.

Also adds a short update to the `README.md` to explain how to check the gRPC results.