### PR TITLE
Split versions for full-node/off-chain actors

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,16 @@ NODE_HOSTNAME=
 # Deployment env vars
 NETWORK_NAME=testnet-validated
 POKTROLLD_IMAGE_REPO=ghcr.io/pokt-network/poktrolld
-POKTROLLD_IMAGE_TAG=0.0.9-1 # latest
+
+# The version of the image to run off-chain components such as RelayMiner and AppGate.
+# Adjust the value when need to upgrade off-chain actors.
+POKTROLLD_IMAGE_TAG_OFF_CHAIN=0.0.9-3 # latest
+
+# The version of the image to use for the full-node. As the network upgrades, the full-node will be upgraded automatically
+# using cosmovisor. That value can be adjusted **after** the upgrade, though not necessary for normal operations.
+# Should match the value here when synching the full-node from genesis: 
+# https://github.com/pokt-network/pocket-network-genesis/blob/master/poktrolld/testnet-validated.init-version
+POKTROLLD_IMAGE_TAG_VALIDATOR=0.0.9
 POKTROLLD_LOG_LEVEL=info
 
 # Credentials for AppGateServer, Gateway and RelayMiner

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 poktrolld-data/data
+poktrolld-data/data-backup*
 poktrolld-data/config/genesis.json
 poktrolld-data/config/genesis.seeds
 poktrolld-data/config/node_key.json

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ gateway/config/config.toml
 .vscode
 prometheus/data
 grafana/data
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   # Full node
   full-node:
     container_name: full-node
-    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG:-latest}
+    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG_VALIDATOR:-latest}
     entrypoint: ["sh", "/home/pocket/start-poktrolld.sh"]
     environment:
       - NODE_HOSTNAME=${NODE_HOSTNAME}
@@ -38,7 +38,7 @@ services:
 
   # Relay Miner
   relayminer:
-    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG:-latest}
+    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG_OFF_CHAIN:-latest}
     container_name: relayminer
     entrypoint: ["sh", "/home/pocket/start-relayminer.sh"]
     environment:
@@ -55,7 +55,7 @@ services:
 
   # AppGate Server
   appgate:
-    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG:-latest}
+    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG_OFF_CHAIN:-latest}
     container_name: appgate
     entrypoint: ["sh", "/home/pocket/start-appgate.sh"]
     environment:
@@ -72,7 +72,7 @@ services:
 
   # Gateway
   gateway:
-    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG:-latest}
+    image: ${POKTROLLD_IMAGE_REPO}:${POKTROLLD_IMAGE_TAG_OFF_CHAIN:-latest}
     container_name: gateway
     entrypoint: ["sh", "/home/pocket/start-gateway.sh"]
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       prepare-full-node:
         condition: service_completed_successfully
     volumes:
+      - /etc/ssl/:/etc/ssl/
       - ./poktrolld-data:/home/pocket/.poktroll/
       - ./scripts/start-poktrolld.sh:/home/pocket/start-poktrolld.sh
       - ./stake_configs:/poktroll/stake_configs

--- a/scripts/init-poktrolld.sh
+++ b/scripts/init-poktrolld.sh
@@ -24,6 +24,9 @@ if [ -n "$NETWORK_NAME" ]; then
       exit 1
     fi
   fi
+
+  # TODO_CONSIDER: we can pull the binary using https://github.com/pokt-network/pocket-network-genesis/blob/master/poktrolld/testnet-validated.init-version
+  # here. For now - let's rely on the correct initial version set in .env.
 else
   echo "NETWORK_NAME variable not set. Please set it to either 'testnet' or 'mainnet'."
   exit 1

--- a/scripts/start-poktrolld.sh
+++ b/scripts/start-poktrolld.sh
@@ -9,7 +9,7 @@ export DAEMON_NAME="poktrolld"
 export DAEMON_HOME="$HOME/.poktroll"
 export DAEMON_RESTART_AFTER_UPGRADE=true
 export DAEMON_ALLOW_DOWNLOAD_BINARIES=true
-export UNSAFE_SKIP_BACKUP=true
+export UNSAFE_SKIP_BACKUP=false
 
 # Ensure required environment variables are set
 : "${NODE_HOSTNAME:?Need to set NODE_HOSTNAME}"


### PR DESCRIPTION
Can go through an upgrade now! :) 

```

7:49PM INF successfully updated the relay mining difficulty for 0 services method=EndBlocker module=x/tokenomics
7:49PM INF finalized block block_app_hash=BB482B9C6AD8695F06C6B6E7FBAB147A4EFB82DD68D318D31109CD0CDF43793B height=17102 module=state num_txs_res=1 num_val_updates=0
7:49PM INF executed block app_hash=BB482B9C6AD8695F06C6B6E7FBAB147A4EFB82DD68D318D31109CD0CDF43793B height=17102 module=state
7:49PM INF committed state block_app_hash=E98192590BE00B75568371476C60C12C565B3FC7EDECAF770125C0928668FA1C height=17102 module=state
7:49PM ERR UPGRADE "v0.0.9-3" NEEDED at height: 17102: {"binaries":{"linux/amd64":"https://github.com/pokt-network/poktroll/releases/download/v0.0.9-3/poktroll_linux_amd64.tar.gz?checksum=sha256:4016aab56bc3bd892
dfbcdd6a872092645c51b039383ff7b34467a9faca3fb60","linux/arm64":"https://github.com/pokt-network/poktroll/releases/download/v0.0.9-3/poktroll_linux_arm64.tar.gz?checksum=sha256:2c74578fcafca8f24bf68539e1732dc8b07c
a51436acf1119e9ca49919a19ea5","darwin/amd64":"https://github.com/pokt-network/poktroll/releases/download/v0.0.9-3/poktroll_darwin_amd64.tar.gz?checksum=sha256:f8377de3c910b680b007c07b7cbe6098672147850aba43225563e
d2ce4359e20","darwin/arm64":"https://github.com/pokt-network/poktroll/releases/download/v0.0.9-3/poktroll_darwin_arm64.tar.gz?checksum=sha256:01e9b179c6bdcc5b2ee73dc3f70aa967fe6407e5628deb26791fe55c9b09d5a2"}} mo
dule=x/upgrade
7:49PM INF starting to take backup of data directory backup start time=2024-10-11T19:49:04Z module=cosmovisor
7:49PM INF backup completed backup completion time=2024-10-11T19:49:04Z backup saved at=/home/pocket/.poktroll/data-backup-2024-10-11 module=cosmovisor time taken to complete backup=538.922005
7:49PM INF no upgrade binary found, beginning to download it module=cosmovisor
7:49PM INF downloading binary complete module=cosmovisor
7:49PM INF pre-upgrade command does not exist. continuing the upgrade. module=cosmovisor
7:49PM INF upgrade detected, relaunching app=poktrolld module=cosmovisor
7:49PM INF running app args=["start","--p2p.external-address=149.28.15.199:26656","--log_level=info","--p2p.seeds=838625e3cfc7a2e347a1afc769957157441f649b@35.184.192.176:26656"] module=cosmovisor path=/home/pocke
t/.poktroll/cosmovisor/upgrades/v0.0.9-3/bin/poktrolld
7:49PM INF starting node with ABCI CometBFT in-process module=server
7:49PM INF service start impl=multiAppConn module=proxy msg="Starting multiAppConn service"
7:49PM INF service start connection=query impl=localClient module=abci-client msg="Starting localClient service"
7:49PM INF service start connection=snapshot impl=localClient module=abci-client msg="Starting localClient service"
7:49PM INF service start connection=mempool impl=localClient module=abci-client msg="Starting localClient service"
7:49PM INF service start connection=consensus impl=localClient module=abci-client msg="Starting localClient service"
7:49PM INF service start impl=EventBus module=events msg="Starting EventBus service"
7:49PM INF service start impl=PubSub module=pubsub msg="Starting PubSub service"
7:49PM INF service start impl=IndexerService module=txindex msg="Starting IndexerService service"
7:49PM INF ABCI Handshake App Info hash=BB482B9C6AD8695F06C6B6E7FBAB147A4EFB82DD68D318D31109CD0CDF43793B height=17102 module=consensus protocol-version=0 software-version=0.0.9-3
7:49PM INF ABCI Replay Blocks appHeight=17102 module=consensus stateHeight=17102 storeHeight=17103
7:49PM INF Replay last block using real app module=consensus
7:49PM INF applying upgrade "v0.0.9-3" at height: 17102 module=x/upgrade
7:49PM INF adding a new module: 06-solomachine module=server
7:49PM INF adding a new module: 07-tendermint module=server
7:49PM INF adding a new module: capability module=server
7:49PM INF adding a new module: feeibc module=server
7:49PM INF adding a new module: ibc module=server
7:49PM INF adding a new module: interchainaccounts module=server
7:49PM INF created new capability module=ibc name=ports/icahost
7:49PM INF port binded module=x/ibc/port port=icahost
7:49PM INF claimed capability capability=1 module=icahost name=ports/icahost
7:49PM INF migrating module tokenomics from version 1 to version 2 module=server
Would migrate the store here, but not doing anything - we don't have anything to migrate.
7:49PM INF adding a new module: transfer module=server
```