### PR TITLE
Upgrade poktrolld image to v0.0.10 and minimum stake amounts

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -13,7 +13,7 @@ POKTROLLD_IMAGE_TAG_OFF_CHAIN=0.0.10 # latest
 # using cosmovisor. That value can be adjusted **after** the upgrade, though not necessary for normal operations.
 # Should match the value here when synching the full-node from genesis: 
 # https://github.com/pokt-network/pocket-network-genesis/blob/master/shannon/alpha/testnet-validated.init-version
-POKTROLLD_IMAGE_TAG_VALIDATOR=0.0.9
+POKTROLLD_IMAGE_TAG_VALIDATOR=0.0.9-4
 POKTROLLD_LOG_LEVEL=info
 
 # Credentials for AppGateServer, Gateway and RelayMiner

--- a/.env.sample
+++ b/.env.sample
@@ -13,7 +13,7 @@ POKTROLLD_IMAGE_TAG_OFF_CHAIN=0.0.10 # latest
 # using cosmovisor. That value can be adjusted **after** the upgrade, though not necessary for normal operations.
 # Should match the value here when synching the full-node from genesis: 
 # https://github.com/pokt-network/pocket-network-genesis/blob/master/shannon/alpha/testnet-validated.init-version
-POKTROLLD_IMAGE_TAG_VALIDATOR=0.0.9-4
+POKTROLLD_IMAGE_TAG_VALIDATOR=0.0.10
 POKTROLLD_LOG_LEVEL=info
 
 # Credentials for AppGateServer, Gateway and RelayMiner

--- a/stake_configs/application_stake_config_example.yaml
+++ b/stake_configs/application_stake_config_example.yaml
@@ -1,3 +1,3 @@
-stake_amount: 1000upokt
+stake_amount: 100000000upokt
 service_ids:
   - 0021

--- a/stake_configs/gateway_stake_config_example.yaml
+++ b/stake_configs/gateway_stake_config_example.yaml
@@ -1,1 +1,1 @@
-stake_amount: 1000upokt
+stake_amount: 100000000upokt

--- a/stake_configs/supplier_stake_config_example.yaml
+++ b/stake_configs/supplier_stake_config_example.yaml
@@ -1,5 +1,5 @@
 # Please check documentation: https://dev.poktroll.com/operate/configs/supplier_staking_config
-stake_amount: 1000upokt
+stake_amount: 1000000upokt
 owner_address: YOUR_OWNER_ADDRESS
 services:
   - service_id: 0021


### PR DESCRIPTION
While following the docs here (https://dev.poktroll.com/operate/quickstart/docker_compose_walkthrough) to create a full-node, I ran into various issues detailed in this PR (https://github.com/pokt-network/poktroll/pull/905).

TLDR: an outdated `poktrolld` image is used: `ghcr.io/pokt-network/poktrolld:0.0.9`. This PR seeks to update this image along with the updated minimum stake amount to encourage easier supplier adoption.

Making these two changes allowed me to successfully stake my supplier and continue along with the docs.

Disclaimer: I'm fairly new to the Pocket community, and potentially other components need updating in this repo to fully support `v0.0.10`. I avoided updating the image to the latest `v0.0.11-rc` until further input from the community can be obtained. 

Thanks!
